### PR TITLE
Add bukkit repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,14 @@
   		</plugin>
   	</plugins>
   </build>
+
+  <repositories>
+  	<repository>
+  		<id>bukkit-reo</id>
+  		<url>http://repo.bukkit.org/content/groups/public</url>
+  	</repository>
+  </repositories>
+
   <dependencies>
   	<dependency>
   		<groupId>org.bukkit</groupId>


### PR DESCRIPTION
Useful if you use jenkins as an integration server and don't want to add a new job for bukkit.
